### PR TITLE
build: fix endOfLine prettier errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,12 @@ module.exports = {
         ],
       },
     ],
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
   },
   settings: {
     react: {


### PR DESCRIPTION
There was an issue with prettier and endOfLine errors causing the user to need to re-save the file in order to fix it sometimes. The end of line sequence for some files were LF and others CRLF. Setting endOfLine  to auto seems to fix this issue.

![image](https://user-images.githubusercontent.com/13560642/233063032-643e9a5c-e024-49bc-9441-7936775a518d.png)
